### PR TITLE
Specify node platform in esbuild options

### DIFF
--- a/register.js
+++ b/register.js
@@ -61,6 +61,7 @@ const extensions = (allowJs ? ['.js', '.jsx'] : []).concat(['.ts', '.tsx'])
 const defaultEsbuildOptions = {
   tsconfig: tsconfig || undefined,
   target: 'node' + process.versions.node.split('.')[0],
+  platform: 'node',
   format: 'cjs',
   sourcemap: 'inline',
   write: false,

--- a/test/basic/test.ts
+++ b/test/basic/test.ts
@@ -2,3 +2,10 @@ import { platform } from 'os'
 import assert from 'assert'
 
 assert.ok(platform())
+assert.match(
+  '' +
+    function () {
+      return process.env.NODE_ENV
+    },
+  /process.env.NODE_ENV/
+)


### PR DESCRIPTION
Currently, this defaults to "browser" (see: https://esbuild.github.io/api/#platform)
- Which then defines process.env.NODE_ENV to development OR production
  based on the minification option.
- Specifying platform=node leaves this alone so you can do `NODE_ENV=XYZ ts-eager foo.ts`

Test plan:
- Added a unit test to make sure that process.env.NODE_ENV is left a lone
- test fails without the fix in register.js
- `npm run test`, `npm run lint`, `npx tsc`, `npx prettier --check .`