### PR TITLE
fix: use js loader for .cjs and .mjs files

### DIFF
--- a/register.js
+++ b/register.js
@@ -12,6 +12,11 @@ const ignoreRegexes = process.env.TS_NODE_IGNORE || '(?:^|/)node_modules/'
 
 const ignores = ignoreRegexes.split(/ *, */g).map((str) => new RegExp(str))
 
+const loaderReplacements = {
+  cjs: 'js',
+  mjs: 'js',
+}
+
 let tsconfig = ''
 let basePath = process.cwd()
 let files = []
@@ -101,10 +106,13 @@ let tsNodeService
 
 const compile = (code, filename) => {
   if (!fileContents.has(filename)) {
+    let loader = extname(filename).slice(1)
+    loader = loaderReplacements[loader] || loader
+
     const { warnings, outputFiles } = buildSync({
       ...defaultEsbuildOptions,
       stdin: {
-        loader: extname(filename).slice(1),
+        loader,
         sourcefile: filename,
         contents: code,
       },


### PR DESCRIPTION
This PR adds support for `.cjs` and `.mjs` files by overriding their loader to `js`.

Per [esbuild's `js` loader docs](https://esbuild.github.io/content-types/#javascript), the `js` loader supports `.cjs` and `.mjs` files and treats them the same as `.js` files.

Without this PR, importing a `.cjs` or `.mjs` file prints the following error:

```
Error: Invalid loader: "cjs" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)

› /[project-path]/node_modules/esbuild/lib/main.js:1209:25
› /[project-path]/node_modules/esbuild/lib/main.js:606:9
› handleIncomingPacket (/[project-path]/node_modules/esbuild/lib/main.js:701:9)
› readFromStdout (/[project-path]/node_modules/esbuild/lib/main.js:573:7)
› runServiceSync (/[project-path]/node_modules/esbuild/lib/main.js:1808:3)
› buildSync (/[project-path]/node_modules/esbuild/lib/main.js:1628:3)
› compile (/[project-path]/register.js:112:39)
› requireExtensions.<computed> (/[project-path]/register.js:164:28)
```
